### PR TITLE
Refactoring for orange actions and blue routing

### DIFF
--- a/.env
+++ b/.env
@@ -3,8 +3,8 @@ APP_ENV=local
 APP_KEY=base64:4VmJkTH36I3uoQrq0rVkL0A2fIttXrrI/p5BkeoHTNE=
 APP_DEBUG=true
 APP_URL=http://localhost
-VITE_ENV = 'local'
-# VITE_ENV = 'production'
+# VITE_ENV = 'local'
+VITE_ENV = 'production'
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
@@ -15,17 +15,17 @@ DB_HOST=127.0.0.1
 
 # LOCAL DATABASE
 
-DB_PORT=8889
-DB_DATABASE=ActivityHub
-DB_USERNAME=ActivityHub
-DB_PASSWORD="AH123"
+# DB_PORT=8889
+# DB_DATABASE=ActivityHub
+# DB_USERNAME=ActivityHub
+# DB_PASSWORD="AH123"
 
 # HOSTED DATABASE
 
-# DB_PORT=3306
-# DB_DATABASE=mgsmusicco_ActivityHub
-# DB_USERNAME=mgsmusicco_ActivityHub
-# DB_PASSWORD="ActivityHub123"
+DB_PORT=3306
+DB_DATABASE=mgsmusicco_ActivityHub
+DB_USERNAME=mgsmusicco_ActivityHub
+DB_PASSWORD="ActivityHub123"
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file

--- a/.env
+++ b/.env
@@ -3,8 +3,8 @@ APP_ENV=local
 APP_KEY=base64:4VmJkTH36I3uoQrq0rVkL0A2fIttXrrI/p5BkeoHTNE=
 APP_DEBUG=true
 APP_URL=http://localhost
-# VITE_ENV = 'local'
-VITE_ENV = 'production'
+VITE_ENV = 'local'
+# VITE_ENV = 'production'
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
@@ -15,17 +15,17 @@ DB_HOST=127.0.0.1
 
 # LOCAL DATABASE
 
-# DB_PORT=8889
-# DB_DATABASE=ActivityHub
-# DB_USERNAME=ActivityHub
-# DB_PASSWORD="AH123"
+DB_PORT=8889
+DB_DATABASE=ActivityHub
+DB_USERNAME=ActivityHub
+DB_PASSWORD="AH123"
 
 # HOSTED DATABASE
 
-DB_PORT=3306
-DB_DATABASE=mgsmusicco_ActivityHub
-DB_USERNAME=mgsmusicco_ActivityHub
-DB_PASSWORD="ActivityHub123"
+# DB_PORT=3306
+# DB_DATABASE=mgsmusicco_ActivityHub
+# DB_USERNAME=mgsmusicco_ActivityHub
+# DB_PASSWORD="ActivityHub123"
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,10 @@
 /storage/*.key
 /vendor
 .env
+/.env
 .env.backup
 .env.production
+.env.example
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml

--- a/app/Http/Controllers/HiresController.php
+++ b/app/Http/Controllers/HiresController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\HiresResource;
+use App\Models\Hire;
+use Illuminate\Http\Request;
+
+class HiresController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return HiresResource::collection(Hire::all());
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Resources/HiresResource.php
+++ b/app/Http/Resources/HiresResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class HiresResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'attributes' => [
+                'start_date' => $this->start_date,
+                'return_date' => $this->return_date,
+                'returned_date' => $this->returned_date,
+                'form_signed' => $this->form_signed,
+                'upload_id' => $this->upload_id,
+                'notes' => $this->notes,
+            ],
+            'instrument' => $this->instrument($this->instrument_id),
+            'student' => $this->student($this->student_id),
+            'timestamps' => [
+                'created' => $this->created_at,
+                'updated' => $this->updated_at,
+                'deleted' => $this->deleted_at
+            ]
+        ];
+    }
+}

--- a/app/Http/Resources/LessonAttendanceResource.php
+++ b/app/Http/Resources/LessonAttendanceResource.php
@@ -26,11 +26,13 @@ class LessonAttendanceResource extends JsonResource
                 'id' => $this->lesson->student->id,
                 'first_name' => $this->lesson->student->first_name,
                 'last_name' => $this->lesson->student->last_name,
+                'full_name' => $this->lesson->student->first_name . " " . $this->lesson->student->last_name,
             ],
             'tutor' => [
                 'id' => $this->lesson->user->id,
                 'first_name' => $this->lesson->user->first_name,
                 'last_name' => $this->lesson->user->last_name,
+                'full_name' => $this->lesson->user->first_name . " " . $this->lesson->user->last_name,
             ],
             'school' => [
                 'id' => $this->lesson->student->school->id,

--- a/app/Http/Resources/LessonsResource.php
+++ b/app/Http/Resources/LessonsResource.php
@@ -42,6 +42,7 @@ class LessonsResource extends JsonResource
                 'id' => $this->user->id,
                 'first_name' => $this->user->first_name,
                 'last_name' => $this->user->last_name,
+                'full_name' => $this->user->first_name . " " . $this->user->last_name,
             ]
         ];
     }

--- a/app/Http/Resources/StaffResource.php
+++ b/app/Http/Resources/StaffResource.php
@@ -19,6 +19,7 @@ class StaffResource extends JsonResource
             'id' => $this->id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
+            'full_name' => $this->first_name . " " . $this->last_name,
             'email' => $this->email,
             'phone' => $this->phone,
             'image' => $this->image,

--- a/app/Http/Resources/StudentsResource.php
+++ b/app/Http/Resources/StudentsResource.php
@@ -18,6 +18,7 @@ class StudentsResource extends JsonResource
             'id' => (string)$this->id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
+            'full_name' => $this->first_name . " " . $this->last_name,
             'year_level' => (string)$this->year_level,
             'contacts' => new ContactsResource($this->contacts),
             'school' => [

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -18,6 +18,7 @@ class UserResource extends JsonResource
             'id' => $this->id,
             'first_name' => $this->first_name,
             'last_name' => $this->last_name,
+            'full_name' => $this->first_name . " " . $this->last_name,
             'image' => $this->image,
             'email' => $this->email,
             'phone' => $this->phone,

--- a/app/Models/Hire.php
+++ b/app/Models/Hire.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use App\Http\Resources\InstrumentResource;
+use App\Http\Resources\StudentsResource;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Hire extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $table = 'instrument_hires';
+    protected $fillable = [
+        'instrument_id',
+        'student_id',
+        'start_date',
+        'return_date',
+        'returned_date',
+        'form_signed',
+        'upload_id',
+        'notes',
+    ];
+
+    public function instrument($instrument_id)
+    {
+        return new InstrumentResource(Instrument::where('id', $instrument_id)->first());
+    }
+
+    public function student($student_id)
+    {
+        return new StudentsResource(Student::where('id', $student_id)->first());
+    }
+}

--- a/resources/js/components/Layouts/MainLayout/ActionBar.vue
+++ b/resources/js/components/Layouts/MainLayout/ActionBar.vue
@@ -131,14 +131,6 @@ function modalCheck(item){
       color: lighten($ah-secondary, 55%);
     }
   }
-  .router-link-exact-active, .active {
-    background-color: $ah-secondary;
-    border-left: 8px solid $ah-secondary-light;
-    color: lighten($ah-secondary, 55%);
-    .linkText {
-      padding: 12px;
-    }
-  }
 }
 
 /* action styles */
@@ -177,7 +169,7 @@ function modalCheck(item){
 .green {
   background-color: rgb(60, 166, 60) !important;
   &:hover {
-    background-color: green !important;
+    background-color: $ah-green-light !important;
   }
 }
 

--- a/resources/js/components/Layouts/MainLayout/Elements/HeaderLine.vue
+++ b/resources/js/components/Layouts/MainLayout/Elements/HeaderLine.vue
@@ -3,13 +3,17 @@
 
     <div id="above-line">
       <span id="heading">{{ heading }}</span>
-      <span v-if="!mobileFormat" id="school">{{ school }}</span>
+      <span v-if="!mobileFormat && (!link1 && !link2)" id="school">{{ school }}</span>
+      <span v-if="!mobileFormat && (link1 || link2)">
+        <button v-if="link1" class="btn btn-outline-primary" @click="$emit('link1', 'link1')">{{ link1 }}</button>
+        <button v-if="link2" class="btn btn-outline-primary" @click="$emit('link2', 'link2')">{{ link2 }}</button>
+      </span>
     </div>
 
     <!-- Dividing Line -->
 
-    <div id="below-line" v-if="mobileFormat">
-      <span id="school">{{ school }}</span>
+    <div id="below-line">
+      <span v-if="mobileFormat || (link1 || link2)" id="school" class="float-right">{{ school }}</span>
     </div>
 
   </div>
@@ -20,14 +24,31 @@ import { useWindowSize } from '/resources/js/composables/useWindowSize';
 
 const props = defineProps({
   heading: String,
-  school: String
+  school: String,
+  link1: String,
+  link2: String,
 })
+
+const emit = defineEmits(['link1', 'link2'])
 
 const { mobileFormat } = useWindowSize()
 
 </script>
 
 <style lang="scss" scoped>
+.btn {
+  margin-bottom: 10px;
+  border-radius: 0;
+  margin-left: 0.25rem;
+  &:first-of-type {
+    border-top-left-radius: 0.75rem;
+    border-bottom-left-radius: 0.75rem;
+  }
+  &:last-of-type {
+    border-top-right-radius: 0.75rem;
+    border-bottom-right-radius: 0.75rem;
+  }
+}
 #header {
   color: $ah-primary-dark;
   margin-bottom: 1.25rem;
@@ -41,6 +62,11 @@ const { mobileFormat } = useWindowSize()
   display:flex;
   border-bottom:3px solid $ah-primary;
 }
+#below-line {
+  justify-content:flex-end;
+  align-items: flex-end;
+  display:flex;
+}
 @media (max-width: 768px){
   #header {
     text-align: center;
@@ -48,6 +74,9 @@ const { mobileFormat } = useWindowSize()
   #heading {
     width: 100%;
     font-size: 1.5rem;
+  }
+  #below-line {
+    justify-content: center;
   }
 }
 </style>

--- a/resources/js/components/Layouts/MainLayout/NavBar.vue
+++ b/resources/js/components/Layouts/MainLayout/NavBar.vue
@@ -69,18 +69,17 @@ function handleProfile(){
 }
 
 const navItems = ref([
-  { header: 'Dashboard', to: { name: 'Dashboard' }, showSubItems: false, icon: icons.house},
+  { header: 'Dashboard', to: { name: 'Dashboard' }, icon: icons.house},
 ])
 
 const navOptions = [
-  { header: 'Lessons', to: { name: 'LessonsList' }, showSubItems: false, icon: icons.chalkboard, permission: 'LESSONS_V', additional_permission: 'LESSONS_R'},
-  // { header: 'Events', to: { name: 'StudentsTable' }, showSubItems: false, icon: 'fa-solid fa-circle', permission: 'EVENTS_V'},
-  // { header: 'Hires', to: { name: 'StudentsTable' }, showSubItems: false, icon: 'fa-solid fa-moon', permission: 'HIRES_V'},
-  // { header: 'Rooms', to: { name: 'StudentsTable' }, showSubItems: false, icon: 'fa-solid fa-book', permission: 'ROOMS_V'},
-  // { header: 'Instruments', to: { name: 'StudentsTable' }, showSubItems: false, icon: 'fa-solid fa-car', permission: 'INSTRUMENTS_V'},
-  { header: 'Students', to: { name: 'StudentsList' }, showSubItems: false, icon: icons.children, permission: 'STUDENTS_V'},
-  { header: 'Instruments', to: { name: 'InstrumentList' }, showSubItems: false, icon: icons.guitar, permission: 'INSTRUMENTS_V'},
-  { header: 'Staff', to: { name: 'StaffList' }, showSubItems: false, icon: icons.userGroup, permission: 'STAFF_V'},
+  { header: 'Lessons', to: { name: 'LessonsList' }, icon: icons.chalkboard, permission: 'LESSONS_V', additional_permission: 'LESSONS_R'},
+  // { header: 'Events', to: { name: 'StudentsTable' }, icon: 'fa-solid fa-circle', permission: 'EVENTS_V'},
+  { header: 'Instruments', to: { name: 'InstrumentList' }, icon: icons.guitar, permission: 'INSTRUMENTS_V'},
+  // { header: 'Hires', to: { name: 'HiresList' }, icon: icons.xmark, permission: 'HIRES_V'},
+  // { header: 'Rooms', to: { name: 'StudentsTable' }, icon: 'fa-solid fa-book', permission: 'ROOMS_V'},
+  { header: 'Students', to: { name: 'StudentsList' }, icon: icons.children, permission: 'STUDENTS_V'},
+  { header: 'Staff', to: { name: 'StaffList' }, icon: icons.userGroup, permission: 'STAFF_V'},
 ]
 function setNavItems(){
   navOptions.forEach(option => {
@@ -152,6 +151,7 @@ function handleSchools(){
   height: 1.25rem;
   margin-right: 1rem;
   margin-left: 1rem;
+  width: 25px;
 }
 #sideBar {
   display: flex;

--- a/resources/js/components/Restricted/Instruments/Hires/HireDetails.vue
+++ b/resources/js/components/Restricted/Instruments/Hires/HireDetails.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <HeaderLine :heading="currentHire.instrument.attributes.name + ' Hire Details'" :school="currentHire.instrument.school.name" />
+  </div>
+</template>
+
+<script setup>
+import { useHireStore } from '/resources/js/stores/hires';
+import HeaderLine from '../../../Layouts/MainLayout/Elements/HeaderLine.vue';
+
+const hireStore = useHireStore()
+const currentHire = hireStore.getHire
+
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/resources/js/components/Restricted/Instruments/Hires/HiresList.vue
+++ b/resources/js/components/Restricted/Instruments/Hires/HiresList.vue
@@ -1,0 +1,81 @@
+<template>
+  <div class="row">
+    <HeaderLine heading="Instrument Hires" link1="Instrument List" @link1="routeChange" />
+
+    <div class="col col-12 col-md-6">
+      <!-- Search input -->
+      <input type="text" class="form-control mb-2" placeholder="Hire search..." v-model="search" disabled>
+    </div>
+
+    <!-- Table component -->
+    <section v-if="filteredHires">
+      <component :is="currentComponent" :hires="filteredHires" :key="key" />
+    </section>
+
+  </div>
+</template>
+
+<script setup>
+import useApi from '/resources/js/composables/useApi';
+import { useWindowSize } from '/resources/js/composables/useWindowSize';
+
+import HeaderLine from '../../../Layouts/MainLayout/Elements/HeaderLine.vue'
+import HiresTable from './ListComponents/HiresTable.vue'
+import HiresTableMobile from './ListComponents/HiresTableMobile.vue';
+
+import { useHireStore } from '/resources/js/stores/hires';
+import { computed, ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+const key = ref(0)
+
+
+// Initiate Stores
+const hireStore = useHireStore()
+
+// Initiate Composables
+const { windowSize } = useWindowSize()
+const router = useRouter()
+
+// Get appropriate component based on window size
+const currentComponent = computed(() => {
+  return windowSize.value.width > 1030 ? HiresTable : HiresTableMobile
+})
+
+// Fetch Hire data and add to store
+const { data: allHires, fetchData: fetchHires } = useApi('hires')
+if(hireStore.getHires.length < 1){
+  fetchHires().then(()=>{
+    hireStore.setHires(allHires.value)
+    key.value++
+  })
+}
+
+// Initiate search variable
+const search = ref('')
+
+// Returns array of hires based on search term, stores array in hire Store
+const filteredHires = computed(() => {
+  const searchTerm = search.value.toLowerCase();
+  const filterFunction = i => (
+    i.name.toLowerCase().includes(searchTerm)
+  );
+
+  const filtered = searchTerm.length > 0
+    ? hireStore.getHires.filter(filterFunction)
+    : hireStore.getHires;
+
+  hireStore.setFilteredHires(filtered);
+  return filtered;
+});
+
+// Handle Route Change
+function routeChange(value){
+  router.push({name: 'InstrumentList'})
+}
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/resources/js/components/Restricted/Instruments/Hires/ListComponents/HiresTable.vue
+++ b/resources/js/components/Restricted/Instruments/Hires/ListComponents/HiresTable.vue
@@ -1,0 +1,74 @@
+<template>  
+<div>
+  <section id="table-header-section">
+    <table>
+      <thead>
+        <tr>
+          <th @click="sortData('hire.name')">Instrument:</th>
+          <th @click="sortData('hire.fee')">Fee:</th>
+          <th @click="sortData('hire.state')">State:</th>
+          <th @click="sortData('hire.notes')" style="width: 50%;">Notes:</th>
+          <th @click="sortData('hire.state')">School:</th>
+        </tr>
+      </thead>
+    </table>
+  </section>
+
+  <section id="table-body-section" style="overflow-y:auto">
+    <table>
+      <tbody>
+        <tr v-for="hire in filteredHires" :key="hire.id" @click="handleClick(hire)">
+          <td>{{ hire.instrument.attributes.name }}</td>
+          <td>{{hire.student.full_name}}</td>
+          <td>{{hire.attributes.start_date}}</td>
+          <td style="width: 50%;">{{hire.attributes.notes}}</td>
+          <td>{{hire.instrument.school.name}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <div class="col-12 col-md-4 totals">
+    <span>Displaying: {{getNum('filtered')}}/{{getNum('total')}}</span>
+  </div>
+  
+</div>
+</template>
+<script setup>
+import { useRouter } from 'vue-router'
+import useSorter from '../../../../../composables/useSorter'
+import { useHireStore } from '../../../../../stores/hires'
+
+
+  const router = useRouter()
+  const sorter = useSorter()
+  const hireStore = useHireStore()
+  const filteredHires = hireStore.getFilteredHires
+
+
+  function handleClick(hire){
+    hireStore.setHire(hire)
+    router.push({
+      name: 'HireDetails'
+    })
+  }
+
+  function getNum(type){
+    if(type === 'filtered'){
+      return hireStore.getFilteredHires.length
+    }
+    if(type === 'total'){
+      return hireStore.getHires.length
+    }
+    return hireStore.getHires.length
+  }
+
+  function sortData(field){
+    sorter.sort(props.lessons, field)
+  }
+
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/resources/js/components/Restricted/Instruments/Hires/ListComponents/HiresTableMobile.vue
+++ b/resources/js/components/Restricted/Instruments/Hires/ListComponents/HiresTableMobile.vue
@@ -1,0 +1,18 @@
+<template>
+  <!-- <div v-for="instrument in instruments" :key="instrument" class="instrument">
+    <InstrumentsTableMobileCard :instrument="instrument" />
+  </div> -->
+</template>
+
+<script setup>
+// import InstrumentsTableMobileCard from './InstrumentsTableMobileCard.vue'
+const props = defineProps({instruments:Array});
+</script>
+
+<style lang="scss" scoped>
+.instrument {
+  &:nth-child(odd){
+    background-color: lighten($ah-primary-background, 6%);
+  }
+}
+</style>

--- a/resources/js/components/Restricted/Instruments/Hires/ListComponents/HiresTableMobileCard.vue
+++ b/resources/js/components/Restricted/Instruments/Hires/ListComponents/HiresTableMobileCard.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="row" :class="{active: active}" @click="active = !active">
+    <div class="col col-10">
+      <p>{{instrument.attributes.name}}</p>
+      <p>{{instrument.attributes.state.description}}</p>
+    </div>
+    <div class="col col-2">
+      <i class="fa-solid fa-magnifying-glass ms-2" :class="{active: active}" @click="InstrumentDetails"></i>
+    </div>
+    <p v-if="active">{{instrument.school.name}}</p>
+    <p v-if="active">{{instrument.attributes.notes}}</p>
+  </div>
+</template>
+
+<script setup>
+import { useInstrumentStore } from "/resources/js/stores/instruments"
+import { ref } from "vue"
+import { useRouter } from "vue-router"
+const props = defineProps({instrument:Object})
+
+const router = useRouter()
+const instrumentStore = useInstrumentStore()
+
+const active = ref(false)
+
+function InstrumentDetails(){
+  instrumentStore.setInstrument(props.instrument)
+  router.push({
+    name: 'InstrumentDetails'
+  })
+}
+
+</script>
+
+<style lang="scss" scoped>
+
+.fa-magnifying-glass {
+  color: $ah-primary;
+  padding: 5px;
+  border: 1px solid $ah-primary;
+  border-radius: 6px;
+  margin-top: 7px;
+}
+.row {
+  padding: 10px;
+}
+.active {
+  background-color: $ah-primary-light;
+  color: lighten($ah-primary-light, 50%);
+  border-bottom: 1px solid $ah-grey;
+  .fa-magnifying-glass {
+    border-color: lighten($ah-primary-light, 50%);
+  }
+}
+p {
+  margin: 0;
+}
+
+
+</style>

--- a/resources/js/components/Restricted/Instruments/InstrumentList.vue
+++ b/resources/js/components/Restricted/Instruments/InstrumentList.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="row">
-    <HeaderLine heading="Instruments" />
+    <HeaderLine heading="Instruments" :link1="links.link1"
+      @link1="routeChange" />
 
     <div class="col col-12 col-md-6">
       <!-- Search input -->
@@ -25,12 +26,16 @@ import InstrumentsTableMobile from './ListComponents/InstrumentsTableMobile.vue'
 
 import { useInstrumentStore } from '/resources/js/stores/instruments';
 import { computed, ref } from 'vue';
+import { useUserStore } from '/resources/js/stores/user';
+import router from '/resources/js/router/router';
 
 const key = ref(0)
+const links = ref({link1: ''})
 
 
 // Initiate Stores
 const instrumentStore = useInstrumentStore()
+const user = useUserStore()
 
 // Initiate Composables
 const { windowSize } = useWindowSize()
@@ -39,6 +44,10 @@ const { windowSize } = useWindowSize()
 const currentComponent = computed(() => {
   return windowSize.value.width > 1030 ? InstrumentsTable : InstrumentsTableMobile
 })
+
+// Set user permission areas
+if(user.hasPermissionAny('HIRES_V')) links.value.link1 = 'Instrument Hire'
+
 
 // Fetch Instrument data and add to store
 const { data: allInstruments, fetchData: fetchInstruments } = useApi('instruments')
@@ -66,6 +75,13 @@ const filteredInstruments = computed(() => {
   instrumentStore.setFilteredInstruments(filtered);
   return filtered;
 });
+
+// Handle route change
+function routeChange(value) {
+  let route = {}
+  if(value === 'link1') route = {name: 'HiresList'}
+  router.push(route)
+}
 
 </script>
 

--- a/resources/js/components/Restricted/Instruments/ListComponents/InstrumentsTable.vue
+++ b/resources/js/components/Restricted/Instruments/ListComponents/InstrumentsTable.vue
@@ -69,47 +69,6 @@ import { useInstrumentStore } from '../../../../stores/instruments'
 
 <style lang="scss" scoped>
 @media (min-width: 768px){
-  table {
-    table-layout: fixed;
-    width: 100%;
-    thead {
-      background-color: $ah-primary;
-      color: white;
-      tr {
-        th {
-          &:first-child {
-            padding-left: 10px;
-            padding-top: 5px;
-            padding-bottom: 5px;
-          }
-        }
-      }
-    }
-    tbody {
-      tr {
-        border-bottom: 1px solid $ah-grey;
-        &:hover {
-          background-color: $ah-primary-background;
-          cursor: pointer;
-        }
-        td {
-          &:first-child {
-            padding: 10px;
-          }
-        }
-      }
-    }
-  }
-  #table-body-section {
-    max-height: calc(100vh - 200px);
-    border-bottom: 5px solid $ah-primary;
-  }
-  .totals {
-    padding-left: 10px;
-    display: inline-flex;
-    align-items: flex-end;
-    justify-content: space-between;
-  }
   .status {
     width: 90px;
     padding: 5px;

--- a/resources/js/components/Restricted/Lessons/Attendance/AttendanceOverview.vue
+++ b/resources/js/components/Restricted/Lessons/Attendance/AttendanceOverview.vue
@@ -1,15 +1,11 @@
 <template>
 <div>
-  <!-- <div id="heading">
-    <h1 style="position:inline-block">Attendance Overview
-    <i style="position:inline-block" class="fa-solid fa-calendar-days float-end" @click="router.push({name: 'LessonAttendanceReview'})"></i></h1>
-  </div> -->
   
   <div v-for="subject in subjectArray" :key="subject">
     <div class="row mb-5 lesson-group" v-if="lessons">
       <h2 class="subjectHeading">{{subject}}</h2>
       <div class="col-12 col-md-4 col-sm-6" v-for="lesson in filteredLessons(subject)" :key="lesson">
-        <AttendanceSnapshot class="snapShot"  :lesson="lesson" :heading="lesson.student.first_name + ' ' + lesson.student.last_name" @click="handleClick(lesson)"/>
+        <AttendanceSnapshot class="snapShot"  :lesson="lesson" :heading="lesson.student.full_name" stats="true" @click="handleClick(lesson)"/>
       </div>
     </div>
   </div>

--- a/resources/js/components/Restricted/Lessons/Attendance/AttendanceReview.vue
+++ b/resources/js/components/Restricted/Lessons/Attendance/AttendanceReview.vue
@@ -22,10 +22,10 @@
         <tr v-for="record in lessons" :key="record">
           <td style="width:10%">{{record.lesson.date}}</td>
           <td style="width:10%">{{record.lesson.time}}</td>
-          <td style="width:15%">{{record.student.first_name}} {{record.student.last_name}}</td>
+          <td style="width:15%">{{record.student.full_name}}</td>
           <td style="width:10%">{{record.lesson.instrument}}</td>
           <td style="width:15%; text-align:center; padding-left:10px; padding-right:10px"><span class="attendance" :class="record.lesson.attendance">{{capitalizeFirstLetter(record.lesson.attendance)}}</span></td>
-          <td style="width:15%">{{record.tutor.first_name}} {{record.tutor.last_name}}</td>
+          <td style="width:15%">{{record.tutor.full_name}}</td>
           <td style="width:20%">{{record.school.name}}</td>
         </tr>
       </tbody>
@@ -64,33 +64,6 @@ function capitalizeFirstLetter(string){
 </script>
 
 <style lang="scss" scoped>
-table {
-  width: 100%;
-  thead {
-    background-color: $ah-primary;
-    color: white;
-    tr th:first-child {
-        padding-left: 10px;
-        padding-top: 5px;
-        padding-bottom: 5px;
-      }
-  }
-  tbody {
-    tr {
-      border-bottom: 1px solid $ah-grey;
-      &:hover {
-        background-color: $ah-primary-background;
-      }
-      td:first-child {
-        padding: 10px;
-      }
-    }
-  }
-}
-#table-body-section {
-  max-height: calc(100vh - 200px);
-  border-bottom: 5px solid $ah-primary;
-}
 #no-records {
   width: 100%;
   text-align: center;

--- a/resources/js/components/Restricted/Lessons/Attendance/AttendanceSingle.vue
+++ b/resources/js/components/Restricted/Lessons/Attendance/AttendanceSingle.vue
@@ -1,18 +1,11 @@
 <template>
   <div>
-    <div class="row mb-3" id="lesson-heading">
-      <div class="col col-12 col-md-8">
-        <h2>{{lesson.student.first_name}} {{lesson.student.last_name}}'s Attendance: </h2>
-        <h3>{{lesson.attributes.instrument}} lessons with {{lesson.tutor.first_name}} {{lesson.tutor.last_name}}</h3>
-      </div>
-      <div class="col col-12 col-md-4">
-        <div id="detailsBtn" class="float-end btn btn-outline-primary form-control mb-2" @click="routeChange({name: 'LessonDetails', params: {id: lesson.id}})">Lesson Details</div>
-      </div>
-    </div>
+    <HeaderLine :heading="lesson.student.full_name + `'s Attendance:`" :school="lesson.attributes.instrument + ' lessons with ' + lesson.tutor.full_name"
+      link1="Lesson Details" @link1="routeChange({name: 'LessonDetails'})"/>
     
     <div class="row mb-4">
       <div class="col-12 col-sm-4">
-        <AttendanceSnapshot :lesson="lesson" heading="Overall Attendance" />
+        <AttendanceSnapshot :lesson="lesson" heading="Overall Attendance" stats="true" />
       </div>
     </div>
 
@@ -33,6 +26,7 @@ import AttendanceTable from './AttendanceTable.vue'
 import { useRouter } from 'vue-router'
 import { useFilterStore } from '../../../../stores/filter'
 import { useLessonsStore } from '../../../../stores/lessons'
+import HeaderLine from '/resources/js/components/Layouts/MainLayout/Elements/HeaderLine.vue'
 
 const lessonStore = useLessonsStore()
 const filter = useFilterStore()

--- a/resources/js/components/Restricted/Lessons/Attendance/AttendanceSnapshot.vue
+++ b/resources/js/components/Restricted/Lessons/Attendance/AttendanceSnapshot.vue
@@ -1,14 +1,14 @@
 <template>
-  <div>
-    <h4>{{getHeading()}}</h4>
+  <div id="snapshot">
+    <h4 style="display: flex; justify-content: space-between;"><span>{{getHeading()}}</span> <span id="total">{{ total }}</span></h4>
     <div class="progress" style="height: 10px; padding:0">
       <div class="progress-bar bg-primary" role="progressbar" aria-label="Example 20px high" :style="'width: '+ getPercentage(present) + '%;'" :aria-valuenow="present" aria-valuemin="0" aria-valuemax="100"></div>
       <div class="progress-bar bg-secondary-dark" role="progressbar" aria-label="Example 20px high" :style="'width: '+ getPercentage(late) + '%;'" :aria-valuenow="late" aria-valuemin="0" aria-valuemax="100"></div>
       <div class="progress-bar bg-red" role="progressbar" aria-label="Example 20px high" :style="'width: '+ getPercentage(absent) + '%;'" :aria-valuenow="absent" aria-valuemin="0" aria-valuemax="100"></div>
       <div class="progress-bar bg-green" role="progressbar" aria-label="Example 20px high" :style="'width: '+ getPercentage(custom) + '%;'" :aria-valuenow="custom" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
-    <p style="display:flex; justify-content:space-between">
-      <span style="font-weight:500">Lessons: {{total}}</span>
+    <p v-if="stats" style="display:flex; justify-content:space-between">
+      <!-- <span style="font-weight:500">Lessons: {{total}}</span> -->
       <span class="text-primary" :class="{faded: present < 1}">Present: {{present}}</span>
       <span class="text-secondary-dark" :class="{faded: late < 1}">Late: {{late}}</span>
       <span class="text-red" :class="{faded: absent < 1}">Absent: {{absent}}</span>
@@ -23,7 +23,8 @@ import { useLessonsStore } from "../../../../stores/lessons"
 
 const props = defineProps({
   lesson: Object,
-  heading: String
+  heading: String,
+  stats: Boolean
 })
  
 const lessonStore = useLessonsStore()
@@ -51,6 +52,19 @@ function getPercentage(value) {
 </script>
 
 <style lang="scss" scoped>
+#snapshot {
+  max-width: 300px;
+}
+#total {
+  color: white;
+  display: inline-block;
+  height: 35px;
+  width: 35px;
+  background-color: $ah-primary;
+  padding: 5px;
+  border-radius: 50%;
+  text-align: center;
+}
 .faded {
   opacity: 0;
 }

--- a/resources/js/components/Restricted/Lessons/Attendance/AttendanceTable.vue
+++ b/resources/js/components/Restricted/Lessons/Attendance/AttendanceTable.vue
@@ -1,30 +1,37 @@
 <template>
 <div>
   <h3>Attendance Entries</h3>
-  <table>
-    <thead>
-      <tr>
-        <th>Day:</th>
-        <th>Date:</th>
-        <th>Time:</th>
-        <th>Attendance:</th>
-        <th class="hide">Recorded By:</th>
-        <th class="hide">Last Modified:</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="record in attendanceRecords" :key="record">
-        <td>{{getDay(record.date)}}</td>
-        <td>{{record.date}}</td>
-        <td>{{record.time}}</td>
-        <td><span class="attendance" :class="record.attendance">{{capitalizeFirstLetter(record.attendance)}}</span></td>
-        <td class="hide">{{lesson.tutor.first_name}} {{lesson.tutor.last_name}}</td>
-        <td class="hide">{{formatModified(record.updated_at)}}</td>
-        <td><i class="fa-solid fa-edit"></i></td>
-      </tr>
-    </tbody>
-  </table>
+  <section id="table-header-section">
+    <table>
+      <thead>
+        <tr>
+          <th>Day:</th>
+          <th>Date:</th>
+          <th>Time:</th>
+          <th>Attendance:</th>
+          <th class="hide">Recorded By:</th>
+          <th class="hide">Last Modified:</th>
+          <th></th>
+        </tr>
+      </thead>
+    </table>
+  </section>
+
+  <section id="table-body-section" style="overflow-y: auto;">
+    <table>
+      <tbody>
+        <tr v-for="record in attendanceRecords" :key="record">
+          <td>{{getDay(record.date)}}</td>
+          <td>{{record.date}}</td>
+          <td>{{record.time}}</td>
+          <td><span class="attendance" :class="record.attendance">{{capitalizeFirstLetter(record.attendance)}}</span></td>
+          <td class="hide">{{lesson.tutor.first_name}} {{lesson.tutor.last_name}}</td>
+          <td class="hide">{{formatModified(record.updated_at)}}</td>
+          <td><i class="fa-solid fa-edit"></i></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
 </div>
 </template>
 
@@ -60,29 +67,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-table {
-  width: 100%;
-  thead {
-    background-color: $ah-primary;
-    color: white;
-    tr th:first-child {
-        padding-left: 10px;
-        padding-top: 5px;
-        padding-bottom: 5px;
-      }
-  }
-  tbody {
-    tr {
-      border-bottom: 1px solid $ah-grey;
-      &:hover {
-        background-color: $ah-primary-background;
-      }
-      td:first-child {
-        padding: 10px;
-      }
-    }
-  }
-}
 .attendance {
   display: block;
   text-align: center;

--- a/resources/js/components/Restricted/Lessons/DetailsComponents/Details.vue
+++ b/resources/js/components/Restricted/Lessons/DetailsComponents/Details.vue
@@ -2,72 +2,69 @@
   <div id="lesson-details" class="section row">
     <h2 class="heading2">Lesson Details:</h2>
     <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>Status:</h3>
+      <AttendanceSnapshot :lesson="lesson" @click="handleAttendanceClick" />
+    </div>
+    <div class="col col-12 col-sm-6 col-md-3">
+      <div><h3>Status:</h3>
         <span :class="lesson.attributes.status.toLowerCase()">{{lesson.attributes.status}}</span>
-      </span>
+      </div>
+      <div><h3>Tutor:</h3>
+      {{lesson.tutor.full_name}}</div>
     </div>
     <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>Lesson Day:</h3>
-      <span v-if="lesson.attributes.day != 'Not Set'">{{lesson.attributes.day}}</span>
-    </span>
-    </div>
-    <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>Lesson Time:</h3>
+      <div>
+        <h3>Lesson Day:</h3>
+        <span v-if="lesson.attributes.day != 'Not Set'">{{lesson.attributes.day}}</span>
+      </div>
+      <div><h3>Lesson Time:</h3>
         <span v-if="lesson.attributes.start != null">
           {{convertTime(lesson.attributes.start)}}
           <span v-if="lesson.attributes.end"> - {{convertTime(lesson.attributes.end)}}</span>
         </span>
-      </span>
+      </div>
+    </div>
+    <div class="col col-12 col-sm-6 col-md-3">
+      <div><h3>Funding:</h3>
+      {{lesson.attributes.funding_type}}</div>
+      <div><h3>Start Date:</h3>
+      {{convertDate(lesson.attributes.startDate)}}</div>
+      <div v-if="lesson.attributes.endDate"><h3>End Date:</h3>
+      {{convertDate(lesson.attributes.endDate)}}</div>
     </div>
     <div class="col col-12 col-sm-6 col-md-3" v-if="lesson.location">
       <span><h3>Location:</h3>
       {{lesson.location.room_name}}</span>
-    </div>
-    <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>Tutor:</h3>
-      {{lesson.tutor.first_name}} {{lesson.tutor.last_name}}</span>
-    </div>
-    <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>Funding:</h3>
-      {{lesson.attributes.funding_type}}</span>
-    </div>
-    <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>Start Date:</h3>
-      {{convertDate(lesson.attributes.startDate)}}</span>
-    </div>
-    <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>End Date:</h3>
-      {{convertDate(lesson.attributes.endDate)}}</span>
-    </div>
-    <div class="col col-12 col-sm-6 col-md-3">
-      <span><h3>School:</h3>
-      {{lesson.school.name}}</span>
     </div>
   </div>
 </template>
 
 <script>
 import moment from 'moment'
+import AttendanceSnapshot from '../Attendance/AttendanceSnapshot.vue'
+import { useRouter } from 'vue-router';
 
 export default {
-  props: {
-    lesson: Object
-  },
-  setup(){
-
-    function convertTime(time){
-      return moment(time, 'HH:mm:ss').format('h:mm A')
-    }
-    function convertDate(date){
-      return moment(date).format('LL') != 'Invalid date' ? moment(date).format('LL') : 'Not set'
-    }
-
-    return {
-      convertTime,
-      convertDate,
-    }
-  }
-
+    props: {
+        lesson: Object
+    },
+    setup() {
+      const router = useRouter()
+        function convertTime(time) {
+            return moment(time, 'HH:mm:ss').format('h:mm A');
+        }
+        function convertDate(date) {
+            return moment(date).format('LL') != 'Invalid date' ? moment(date).format('LL') : 'Not set';
+        }
+        function handleAttendanceClick(){
+          router.push({name: 'LessonAttendanceSingle'})
+        }
+        return {
+            convertTime,
+            convertDate,
+            handleAttendanceClick,
+        };
+    },
+    components: { AttendanceSnapshot }
 }
 </script>
 

--- a/resources/js/components/Restricted/Lessons/DetailsComponents/Header.vue
+++ b/resources/js/components/Restricted/Lessons/DetailsComponents/Header.vue
@@ -1,12 +1,8 @@
 <template>
-<div class="row">
-  <HeaderLine :heading="heading" :school="lesson.school.name" />
-  <!-- <div class="col-12 col-md-9">
-    <button class="btn btn-outline-primary" style="width: 150px;" @click="viewStudent">View Student</button>
-  </div>
-  <div class="d-none d-xl-block col-12 col-md-3"> -->
-    <attendance-snapshot :lesson="lesson" />
-  <!-- </div> -->
+<div>
+  <HeaderLine :heading="heading" :school="lesson.school.name" :link1="links.link1" :link2="links.link2"
+    @link1="handleClick" @link2="handleClick" />
+    <!-- <attendance-snapshot :lesson="lesson" /> -->
 </div>
   
 </template>
@@ -33,6 +29,9 @@ export default {
 
     const heading = `${props.lesson.student.first_name} ${props.lesson.student.last_name}${getSIfNeeded()} ${props.lesson.attributes.instrument} Lessons`
 
+    const links = {link1: 'View Notes', link2: 'View Attendance'}
+
+
     function getSIfNeeded(){
       return props.lesson.student.last_name.slice(-1) != "s" ? "'s" : "'"
     }
@@ -42,9 +41,18 @@ export default {
       router.push({ name: 'StudentDetails'})
     }
 
+    function handleClick(value){
+      let route = []
+      if(value === 'link1') route = 'LessonNotes'
+      if(value === 'link2') route = 'LessonAttendanceSingle'
+      router.push({name: route})
+    }
+
     return {
       getSIfNeeded,
       viewStudent,
+      handleClick,
+      links,
       user,
       heading
     }

--- a/resources/js/components/Restricted/Lessons/LessonCreate.vue
+++ b/resources/js/components/Restricted/Lessons/LessonCreate.vue
@@ -16,11 +16,13 @@
       <div class="col col-12 col-sm-6">
         <label>Student:</label>
         <select name="studentName" class="form-control" required v-model="formData.student">
-          <option v-for="student in data.students" :key="student.id" :value="student.id">{{student.first_name}} {{student.last_name}}</option>
+          <option v-for="student in data.students" :key="student.id" :value="student.id">{{student.full_name}}</option>
         </select>
       </div>
+
       <div class="col col-12 col-sm-6">
       </div>
+
     </div>
 
     <div class="row">

--- a/resources/js/components/Restricted/Lessons/LessonDetails.vue
+++ b/resources/js/components/Restricted/Lessons/LessonDetails.vue
@@ -39,18 +39,14 @@ import { useUserStore } from '@/stores/user';
     const actionsArray = []
     if(user.hasPermission('LESSONS_R', lesson.value.school.id) || user.hasPermission('LESSONS_V', lesson.value.school.id)){
       actionsArray.push(
-        { header: 'Add Lesson Notes', to: { name: 'LessonCreateNote' }, icon: 'fa-solid fa-file-circle-plus', additional: true},
-        { header: 'View Lesson Notes', to: { name: 'LessonNotes' }, icon: 'fa-solid fa-eye', additional: true},
+        { header: 'Add Lesson Notes', to: { name: 'LessonDetails' }, modal: 'LessonCreateNote', icon: 'fa-solid fa-file-circle-plus', additional: true},
         { header: 'Edit Lesson', to: { name: 'LessonDetails', route: {id: lesson.value.attributes.id} }, modal: 'EditLesson', icon: 'fa-solid fa-edit', additional: true})
-    }
-    if(user.hasPermission('ATTENDANCE_R', lesson.value.school.id) || user.hasPermission('ATTENDANCE_V')){
-      actionsArray.push({ header: 'View Attendance', to: { name: 'LessonAttendanceSingle' }, icon: 'fa-solid fa-user-check', additional: true})
     }
     if(user.hasPermission('LESSONS_D', lesson.value.school.id)){
       actionsArray.push({ header: 'Delete Lesson', to: { name: 'LessonDetails' }, modal: 'DeleteLesson', icon: 'fa-solid fa-trash', additional: true, red: true})
     }
     if(lesson.value.attributes.status != 'Active' && lessonDetailsSet()){
-      actionsArray.unshift({ header: 'Set Lesson as Active', to: { name: 'LessonConfirmActive' }, icon: 'fa-solid fa-circle-check', additional: true, green: true})
+      actionsArray.unshift({ header: 'Set Lesson as Active', to: { name: 'LessonDetails' }, modal: "LessonConfirmActive", icon: 'fa-solid fa-circle-check', additional: true, green: true})
     }
     actions.setItems(actionsArray)
   }
@@ -67,6 +63,7 @@ import { useUserStore } from '@/stores/user';
 
   watch(() => lessonStore.singleLesson, (newValue) => {
     lesson.value = newValue
+    setActions()
   }, {deep: true})
 
 </script>

--- a/resources/js/components/Restricted/Lessons/LessonNotes.vue
+++ b/resources/js/components/Restricted/Lessons/LessonNotes.vue
@@ -1,17 +1,21 @@
 <template>
-  <div class="container body-notes" v-if="allNotes.length > 0">
-    <div v-for="comment in allNotes" :key="comment.id" class="comment-container">
-      <span id="comment-section">
-        <div class="comment-date">{{convertDate(comment.created_at)}} - {{comment.created_by.first_name}} {{comment.created_by.last_name}}</div>
-        <div class="comment">"{{comment.comment}}"</div>
-      </span>
-      <div v-html="icons.trash" class="trash" @click="handleNoteDelete(comment)"></div>
-    </div>    
-  </div>
-  <div v-else class="container text-center mt-5">
-    <h2>It looks like there are no notes to display!</h2>
-    <button class="btn btn-primary mx-2" @click="handleReturnToDetails">Return to Lesson Details</button>
-    <button class="btn btn-secondary mx-2" @click="handleAddNote">Make a Note</button>
+  <div>
+    <HeaderLine heading="Lesson Notes" :school="subHeading" link1="Student Details" @link1="handleReturnToDetails" />
+    <div></div>
+    <div class="container body-notes" v-if="allNotes.length > 0">
+      <div v-for="comment in allNotes" :key="comment.id" class="comment-container">
+        <span id="comment-section">
+          <div class="comment-date">{{convertDate(comment.created_at)}} - {{comment.created_by.first_name}} {{comment.created_by.last_name}}</div>
+          <div class="comment">"{{comment.comment}}"</div>
+        </span>
+        <div v-html="icons.trash" class="trash" @click="handleNoteDelete(comment)"></div>
+      </div>    
+    </div>
+    <div v-else class="container text-center mt-5">
+      <h2>It looks like there are no notes to display!</h2>
+      <button class="btn btn-primary mx-2" @click="handleReturnToDetails">Return to Lesson Details</button>
+      <button class="btn btn-secondary mx-2" @click="handleAddNote">Make a Note</button>
+    </div>
   </div>
 </template>
 
@@ -23,11 +27,15 @@ import { useLessonsStore } from '@/stores/lessons'
 import { icons } from '@/images/icons/icons'
 import { useModalStore } from '@/stores/modal'
 import { useRouter } from 'vue-router'
+import HeaderLine from '../../Layouts/MainLayout/Elements/HeaderLine.vue'
 
 const emits = defineEmits(['close'])
 const lessonStore = useLessonsStore()
+const currentLesson = lessonStore.getLessonData
 const modal = useModalStore()
 const router = useRouter()
+
+const subHeading = `${currentLesson.student.full_name} ${currentLesson.attributes.instrument} Lessons`
   
 const allNotes = computed(()=>{
   return lessonStore.getLessonData.notes
@@ -48,10 +56,7 @@ function handleAddNote(){
 
 function handleReturnToDetails(){
   router.push({
-    name: 'LessonDetails',
-    params: {
-      id: lessonStore.getLessonData.id
-    }
+    name: 'LessonDetails'
   })
 }
 
@@ -59,7 +64,7 @@ function handleReturnToDetails(){
 
 <style lang="scss" scoped>
 .body-notes {
-  height: calc(100vh - 110px);
+  height: calc(100vh - 250px);
   display: flex;
   flex-direction: column;
   background: white;

--- a/resources/js/components/Restricted/Lessons/LessonsList.vue
+++ b/resources/js/components/Restricted/Lessons/LessonsList.vue
@@ -1,7 +1,8 @@
 <template>
 <div>
   <!-- Header -->
-  <HeaderLine heading="Lessons" />
+  <HeaderLine heading="Lessons" link1="Attendance Data" link2="Lesson Requests" 
+    @link1="changeRoute" @link2="changeRoute"/>
 
   <!-- Table component -->
   <section v-if="filteredLessons">
@@ -23,6 +24,7 @@ import LessonsTableMobile from './ListComponents/LessonsTableMobile.vue'
 import { useActionsStore } from '../../../stores/actions'
 import { useLessonsStore } from '../../../stores/lessons'
 import { useUserStore } from '@/stores/user'
+import { useRouter } from 'vue-router'
 
 //  Initiate Stores
 const filter = useFilterStore()
@@ -31,6 +33,7 @@ const actions = useActionsStore()
 const user = useUserStore()
 
 // Initiate Composables
+const router = useRouter()
 const { windowSize } = useWindowSize()
 
 // Get appropriate component based on window size
@@ -49,25 +52,32 @@ fetchData().then(() => {
     filter.setData(lessons.value)
     filter.setType('LessonsForm')
   },300)
-  
 })
 
 // Set side actions available on this page
 const actionArray = []
-if(user.hasPermissionAny('LESSONS_REQ_R') || user.hasPermission('LESSONS_REQ_V')){
-  actionArray.push({ header: 'Lesson Requests', to: { name: 'LessonRequests' }, showSubItems: false, icon: 'fa-solid fa-square-plus'})
-}
 if(user.hasPermissionAny('LESSONS_C')){
-  actionArray.push({ header: 'New Lesson', to: { name: 'LessonCreate' }, showSubItems: false, icon: 'fa-solid fa-person-chalkboard'})
-}
-if(user.hasPermissionAny('ATTENDANCE_R') || user.hasPermission('ATTENDANCE_V')){
-  actionArray.push({ header: 'Attendance', to: { name: 'LessonAttendanceOverview' }, icon: 'fa-solid fa-user-check', additional: true})
+  actionArray.push({ header: 'Create New Lesson', to: { name: 'LessonCreate' }, showSubItems: false, icon: 'fa-solid fa-person-chalkboard'})
 }
 actions.setItems(actionArray)
+
+// if(user.hasPermissionAny('ATTENDANCE_R') || user.hasPermission('ATTENDANCE_V')){
+//   actionArray.push({ header: 'Attendance', to: { name: 'LessonAttendanceOverview' }, icon: 'fa-solid fa-user-check', additional: true})
+// }
+// if(user.hasPermissionAny('LESSONS_REQ_R') || user.hasPermission('LESSONS_REQ_V')){
+//   actionArray.push({ header: 'Lesson Requests', to: { name: 'LessonRequests' }, showSubItems: false, icon: 'fa-solid fa-square-plus'})
+// }
 
 // Check for update to filtered lessons and display to user
 watch(() => filter.getReturned, (newValue) => {
   filteredLessons.value = newValue
 })
+
+function changeRoute(value){
+  let newRoute = {}
+  if(value === 'link1') newRoute = 'LessonAttendanceOverview'
+  if(value === 'link2') newRoute = 'LessonRequests'
+  router.push({name: newRoute})
+}
 
 </script>

--- a/resources/js/components/Restricted/Lessons/ListComponents/LessonsTable.vue
+++ b/resources/js/components/Restricted/Lessons/ListComponents/LessonsTable.vue
@@ -3,7 +3,7 @@
     <table>
       <thead>
         <tr>
-          <th @click="sortData('student.last_name')">Student Name:</th>
+          <th @click="sortData('student.last_name')">Student:</th>
           <th @click="sortData('student.year_level')">Year:</th>
           <th @click="sortData('attributes.instrument')">Instrument:</th>
           <th @click="sortData('attributes.day')">Lesson Day:</th>
@@ -21,12 +21,12 @@
     <table>
       <tbody>
         <tr v-for="lesson in lessons" :key="lesson.id" @click="handleLessonClick(lesson)" :class="lesson.attributes.status">
-          <td>{{lesson.student.first_name}} {{lesson.student.last_name}}</td>
+          <td>{{lesson.student.full_name}}</td>
           <td>{{lesson.student.year_level || '-'}}</td>
           <td>{{lesson.attributes.instrument}}</td>
           <td>{{lesson.attributes.day || '-'}}</td>
           <td>{{formatTime(lesson.attributes.start) || '-'}}</td>
-          <td>{{lesson.tutor.first_name}} {{lesson.tutor.last_name}}</td>
+          <td>{{lesson.tutor.full_name}}</td>
           <td><span :class="lesson.attributes.funding_type">{{lesson.attributes.funding_type || '-'}}</span></td>
           <td><span class="status btn" :class="lesson.attributes.status + '-td'">{{lesson.attributes.status}}</span></td>
           <td v-if="user.attributes.schools">{{lesson.school.name}}</td>
@@ -96,46 +96,6 @@ export default {
 
 <style lang="scss" scoped>
 @media (min-width: 768px){
-  table {
-    table-layout: fixed;
-    width: 100%;
-    thead {
-      background-color: $ah-primary;
-      color: white;
-      tr {
-        th {
-          &:first-child {
-            padding-left: 10px;
-            padding-top: 5px;
-            padding-bottom: 5px;
-          }
-        }
-      }
-    }
-    tbody {
-      tr {
-        border-bottom: 1px solid $ah-grey;
-        &:hover {
-          background-color: $ah-primary-background;
-          cursor: pointer;
-        }
-        td {
-          &:first-child {
-            padding: 10px;
-          }
-        }
-      }
-    }
-  }
-  #table-body-section {
-    max-height: calc(100vh - 200px);
-    border-bottom: 5px solid $ah-primary;
-  }
-  .totals {
-    display: inline-flex;
-    align-items: flex-end;
-    justify-content: space-between;
-  }
   .status {
     width: 90px;
     padding: 5px;

--- a/resources/js/components/Restricted/Lessons/ListComponents/LessonsTableMobileCard.vue
+++ b/resources/js/components/Restricted/Lessons/ListComponents/LessonsTableMobileCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="row" :class="{active: active}" @click="active = !active">
     <div class="col col-6">
-      <p>{{lesson.student.first_name}} {{lesson.student.last_name}}</p>
+      <p>{{lesson.student.full_name}}</p>
       <p>{{lesson.attributes.instrument}}</p>
     </div>
     <div class="col col-4">

--- a/resources/js/components/Restricted/Lessons/Modals/Attendance/LessonRecordAttendanceSingle.vue
+++ b/resources/js/components/Restricted/Lessons/Modals/Attendance/LessonRecordAttendanceSingle.vue
@@ -3,7 +3,7 @@
   <span style="height:fit-content" v-if="lesson">
     <form style="padding:1rem" @submit.prevent="handleClick('custom')">
       <div class="row">
-        <div class="heading">{{lesson.student.first_name}} {{lesson.student.last_name}}</div>
+        <div class="heading">{{lesson.student.full_name}}</div>
         <div style="text-align:center" :class="{lineThrough: advancedOptions}">{{formatDatetime(currentCalendar.dateTime)}}</div>
         <div class="col-12 col-md-4">
           <input type="button" class="btn btn-green form-control mb-2" value="Present" :disabled="advancedOptions == true" @click="handleClick('present')">

--- a/resources/js/components/Restricted/Lessons/Modals/Attendance/LessonRecordReviewAttendanceSingle.vue
+++ b/resources/js/components/Restricted/Lessons/Modals/Attendance/LessonRecordReviewAttendanceSingle.vue
@@ -2,7 +2,7 @@
   <h2 class="text-items:center">Editing Attendance</h2>
   <form style="padding:1rem" @submit.prevent="submitRecord">
     <div class="row">
-      <div class="heading">{{lesson.student.first_name}} {{lesson.student.last_name}}</div>
+      <div class="heading">{{lesson.student.full_name}}</div>
       <div class="col-12 col-md-4">
         <label for="date">Lesson date:</label>
         <input type="date" id="date" class="form-control" required :max="today" v-model="attendanceData.date">

--- a/resources/js/components/Restricted/Lessons/Modals/LessonConfirmActive.vue
+++ b/resources/js/components/Restricted/Lessons/Modals/LessonConfirmActive.vue
@@ -1,14 +1,13 @@
 <template>
-<modal-template-vue title="Set Lesson As Active" :push='returnDetails'>
-  <span style="text-align:center; height:fit-content; background:blue">
-    <div class="mt-5">You are about to set this lesson as 'active'.</div>
+  <div class="text-center">
+    <h2>Set Lesson as Active?</h2>
+    <div>You are about to set this lesson as 'active'.</div>
     <div>Do you wish to continue?</div>
     <form class="mt-3">
-      <input type="button" value="Yes" class="btn btn-primary mx-2" @click="handleClick('Yes')">
       <input type="button" value="Cancel" class="btn btn-grey mx-2" @click="handleClick('Cancel')">
+      <input type="button" value="Yes" class="btn btn-primary mx-2" @click="handleClick('Yes')">
     </form>
-  </span>
-</modal-template-vue>
+  </div>
 
 </template>
 
@@ -17,6 +16,8 @@ import { useRouter } from 'vue-router'
 import { useToast } from 'vue-toast-notification'
 import axiosClient from '../../../../axios'
 import ModalTemplateVue from '../../../Modal.vue'
+import { useLessonsStore } from '/resources/js/stores/lessons'
+import { useModalStore } from '/resources/js/stores/modal'
 
 export default {
   components: {
@@ -25,38 +26,39 @@ export default {
   setup(){
     const router = useRouter()
     const toast = useToast()
+
+    const lessonStore = useLessonsStore()
+    const lesson = lessonStore.getLessonData
+    const modal = useModalStore()
      
 
     function handleClick(click){
       if(click === 'Yes') handleSetActive()
-      if(click === 'Cancel') returnToDetails()
+      if(click === 'Cancel') modal.close()
     }
 
     function handleSetActive(){
-      axiosClient.patch('lessons/' + general.routeData.lesson.id, {status: 'Active'})
+      axiosClient.patch('lessons/' + lesson.id, {status: 'Active'})
       .then((res) => {
         toast.open({ message: res.data.message, duration: 5000, dismissible: true, type: 'success'})
         axiosClient.post('calendar-events', CalendarData())
-        .then(res => {
-          returnToDetails()
+        .then(() => { 
+          lesson.attributes.status = 'Active'
+          modal.close()
         })
       })
     }
 
     function CalendarData(){
       return {
-        school_id: general.routeData.lesson.school.id,
-        user_id: general.routeData.lesson.tutor.id,
-        start: general.routeData.lesson.attributes.startDate ? general.routeData.lesson.attributes.startDate : new Date(),
+        school_id: lesson.school.id,
+        user_id: lesson.tutor.id,
+        start: lesson.attributes.startDate ? lesson.attributes.startDate : new Date(),
         reference_type: 'lesson',
-        reference_type_id: general.routeData.lesson.id
+        reference_type_id: lesson.id
       }
     }
-    const returnDetails = { name: 'LessonDetails', params: { id: general.routeData.lesson.id } }
-
-    function returnToDetails(){
-        router.push(returnDetails)
-    }
+    const returnDetails = { name: 'LessonDetails', params: { id: lesson.id } }
 
     return {
       handleClick,
@@ -67,6 +69,8 @@ export default {
 }
 </script>
 
-<style>
-
+<style lang="scss" scoped>
+input[type = 'button']{
+  width: 100px;
+}
 </style>

--- a/resources/js/components/Restricted/Lessons/Modals/LessonModals.js
+++ b/resources/js/components/Restricted/Lessons/Modals/LessonModals.js
@@ -5,6 +5,7 @@ import LessonCreateNote from "./Notes/LessonCreateNote.vue"
 import LessonNoteDeleteConfirm from './Notes/LessonNoteDeleteConfirm.vue'
 import EditLesson from './LessonEdit.vue'
 import DeleteLesson from './LessonDelete.vue'
+import LessonConfirmActive from './LessonConfirmActive.vue'
 
 
 const lessonModals = {
@@ -15,6 +16,7 @@ const lessonModals = {
   LessonNoteDeleteConfirm,
   EditLesson,
   DeleteLesson,
+  LessonConfirmActive
 }
 
 export default lessonModals;

--- a/resources/js/components/Restricted/Lessons/Requests/RequestReview.vue
+++ b/resources/js/components/Restricted/Lessons/Requests/RequestReview.vue
@@ -16,7 +16,7 @@
         <label for="reviewed-student">Name of Student:</label>
         <span style="display:flex">
           <select id="reviewed-student" class="form-control" v-model="selectedStudent" @change="updateStudentDetails" required>
-            <option v-for="student in students.data" :key="student.id" :value="student">{{student.first_name}} {{student.last_name}}</option>
+            <option v-for="student in students.data" :key="student.id" :value="student">{{student.full_name}}</option>
           </select>
           <!-- <button class="btn btn-primary form-control" style="height:37px; width: 37px"><i class="fa-solid fa-plus"></i></button> -->
         </span>

--- a/resources/js/components/Restricted/Lessons/Requests/RequestsTableMobileCard.vue
+++ b/resources/js/components/Restricted/Lessons/Requests/RequestsTableMobileCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="row" :class="{active: active}" @click="active = !active">
     <div class="col col-6">
-      <p>{{lesson.student.first_name}} {{lesson.student.last_name}}</p>
+      <p>{{lesson.student.full_name}}</p>
       <p>{{lesson.attributes.instrument}}</p>
     </div>
     <div class="col col-4">

--- a/resources/js/components/Restricted/Staff/StaffDetails.vue
+++ b/resources/js/components/Restricted/Staff/StaffDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mt-1">
-    <HeaderLine :heading="staff.first_name + ' ' + staff.last_name" :school="currentSchool.name"/>
+    <HeaderLine :heading="staff.full_name" :school="currentSchool.name"/>
     
     <div class="body row">
       <div class="col col-12 col-md-6">

--- a/resources/js/components/Restricted/Staff/StaffList.vue
+++ b/resources/js/components/Restricted/Staff/StaffList.vue
@@ -2,7 +2,7 @@
   <div>
     <HeaderLine heading="Staff" :school="selectedSchool.name" />
     <div v-if="schoolStore.getSchools" class="tab-header mb-3">
-      <div>
+      <div v-if="schoolStore.getSchools.length > 1">
         <span class="school-tile unselectable" 
         :class="{active: selectedSchool.id === school.id}" 
         v-for="school in schoolStore.getSchools" :key="school.id" 
@@ -72,10 +72,6 @@ if(Object.keys(schoolStore.getSchool).length > 0){
   })
 }
 
-const filteredStaff = computed(() => {
-  return 
-})
-
 // Watch for a change in selected school an update components
 watch(() => selectedSchool.value, (newValue) => {
   schoolStore.setSchool(newValue)
@@ -91,15 +87,12 @@ watch(() => selectedSchool.value, (newValue) => {
   justify-content: space-between;
 }
 .school-tile {
-  display: inline-flex;
-  background: $ah-grey;
-  color: white;
-  padding: 10px;
-  cursor: pointer;
+  color: $ah-grey-dark;
   margin-right: 0.5rem;
-  border-radius: 0.5rem;
   &:hover {
-    background: $ah-grey-dark;
+    color: $ah-grey-dark;
+    border-bottom: 1px solid $ah-grey-dark;
+    cursor: pointer;
   }
 }
 .add-staff {
@@ -113,10 +106,14 @@ watch(() => selectedSchool.value, (newValue) => {
   }
 }
 .active {
-  background: $ah-primary;
-  // box-shadow: 5px 5px 5px $ah-grey;
+  color: $ah-primary;
+  // text-decoration: underline;;
+  font-weight: bold;
+  // background: $ah-primary;
   &:hover {
-    background: $ah-primary;
+    background: transparent;
+    border: none;
+    color: $ah-primary;
     cursor: default;
   }
 }

--- a/resources/js/components/Restricted/Students/DetailsComponents/ContactDetails.vue
+++ b/resources/js/components/Restricted/Students/DetailsComponents/ContactDetails.vue
@@ -4,7 +4,7 @@
     <div id="student" class="col col-12 col-sm-6 col-md-3" v-if="student.contacts.student.email">
       <h2>Student:</h2>
       <h3>Name:</h3>
-      {{student.first_name}} {{student.last_name}}<br/>
+      {{student.full_name}}<br/>
       <h3>Year Level:</h3>
       {{student.year_level}}<br/>
       <h3>Email:</h3>

--- a/resources/js/components/Restricted/Students/DetailsComponents/SingleLessonTile.vue
+++ b/resources/js/components/Restricted/Students/DetailsComponents/SingleLessonTile.vue
@@ -3,7 +3,7 @@
       <div class="row">
         <div class="col col-6">
           <div>{{ lesson.attributes.instrument }}</div>
-          <div>Tutor: {{ lesson.tutor.first_name }} {{ lesson.tutor.last_name }}</div>
+          <div>Tutor: {{ lesson.tutor.full_name }}</div>
         </div>
         <div class="col col-6 text-end">
           <span v-if="lesson.attributes.deleted_at === null">

--- a/resources/js/components/Restricted/Students/ListComponents/StudentsTable.vue
+++ b/resources/js/components/Restricted/Students/ListComponents/StudentsTable.vue
@@ -1,21 +1,27 @@
 <template>
   <div v-if="Object.keys(studentList).length > 0">
-     <table role="table" id="student-table">
-      <thead role="rowgroup" id="table-head">
-        <tr role="row" class="table-heading">
+  <section id="table-header-section">
+     <table>
+      <thead>
+        <tr>
           <th role="columnheader" @click="sortData('first_name')" style="width: 1%">First Name:</th>
           <th role="columnheader" @click="sortData('last_name')" style="width: 1%">Last Name:</th>
           <th role="columnheader" @click="sortData('school.name')" style="width: 1%">School:</th>
         </tr>
       </thead>
-      <tbody role="rowgroup" id="student-data">
-        <tr role="row" class="student-row" v-for="member in studentList" :key="member.id" @click="handleRowClick(member)">
+     </table>
+  </section>
+  <section id="table-body-section" style="overflow-y:auto">
+    <table>
+      <tbody>
+        <tr v-for="member in studentList" :key="member.id" @click="handleRowClick(member)">
           <td role="cell">{{member.first_name}}</td>
           <td role="cell">{{member.last_name}}</td>
           <td role="cell">{{member.school.name}}</td>
         </tr>
       </tbody>
     </table>
+  </section>
   </div>
 </template>
 
@@ -45,62 +51,4 @@ function handleRowClick(member){
 </script>
 
 <style lang="scss" scoped>
-#student-table {
-    width:100%;
-    // overflow-y: scroll;
-    display: block;
-    table-layout: fixed;
-    border-bottom: 2px solid $ah-primary;
-    .table-heading {
-      background-color: $ah-primary;
-      color: white;
-      border-radius: 10px 10px 0 0;
-      th {
-        padding: 10px;
-        width: auto;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        cursor: pointer;
-      }
-    }
-    #student-data{
-      .student-row {
-        border-bottom: thin solid rgb(209, 209, 209);
-        td {
-          padding: 10px;
-          width: auto;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          .special {
-            display: table;
-            padding: 10px 10px;
-            border-radius: 15px;
-            width: 73px;
-            text-align: center;
-          }
-        }
-        &:hover {
-          background-color: lighten($ah-primary, 60%);
-          cursor: pointer;
-          td {
-            color: $ah-primary-dark;
-          }
-        }
-      }
-    }
-  }
-  .tally {
-    margin-right: 2rem;
-  }
-  thead, tbody, tfoot, tr, td, th {
-    width: 100%;
-  }
-  @media (max-width: 768px){
-    #student-table {
-      display: none;
-    }
-  }
-
 </style>

--- a/resources/js/components/Restricted/Students/ListComponents/StudentsTableMobileCard.vue
+++ b/resources/js/components/Restricted/Students/ListComponents/StudentsTableMobileCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="row" :class="{active: active}" @click="active = !active">    
     <div class="col col-7">
-      <p>{{student.first_name}} {{student.last_name}}</p>
+      <p>{{student.full_name}}</p>
     </div>
     <div class="col col-3">
       <p v-if="!active">{{abbreviate(student.school.name)}}</p>

--- a/resources/js/composables/useCalendarEventFormatter.js
+++ b/resources/js/composables/useCalendarEventFormatter.js
@@ -8,7 +8,7 @@ export function useCalendarEventFormatter() {
     // console.log(element)
       let newEvent = {
         id: element.id,
-        title: element.calendar.title ? element.calendar.title : element.reference.data.student.first_name + ' ' + element.reference.data.student.last_name,
+        title: element.calendar.title ? element.calendar.title : element.reference.data.student.full_name,
         startTime: element.reference.data.attributes.start,
         endTime: element.reference.data.attributes.end,
         daysOfWeek: [getWeekDay(element.reference.data.attributes.day)],

--- a/resources/js/router/authRoutes/Hires.js
+++ b/resources/js/router/authRoutes/Hires.js
@@ -1,0 +1,20 @@
+import HiresList from '../../components/Restricted/Hires/HiresList.vue'
+import HireDetails from '../../components/Restricted/Hires/HireDetails.vue'
+import { useHireStore } from '/resources/js/stores/hires'
+
+
+const hireRoutes = [
+  {path: 'hire', meta: {breadcrumb: "Hires"},
+      children: [
+        { path: '', name: 'HiresList', component: HiresList, meta: { title: 'Hires', section: "Hires", depth: 1}},
+        { path: 'details', name: 'HireDetails', component: HireDetails, meta: { title: 'Hire Details', breadcrumb: ' > Details', section: "Hires", depth: 2},
+        beforeEnter: (to, from, next) => {
+          const hireStore = useHireStore()
+          if(Object.keys(hireStore.getHire).length == 0) next({ name: 'HiresList'})
+          else next()
+        }
+      },
+  ]},
+] 
+
+export default hireRoutes;

--- a/resources/js/router/authRoutes/Instruments.js
+++ b/resources/js/router/authRoutes/Instruments.js
@@ -1,6 +1,10 @@
 import InstrumentList from '../../components/Restricted/Instruments/InstrumentList.vue'
 import InstrumentDetails from '../../components/Restricted/Instruments/InstrumentDetails.vue'
 import { useInstrumentStore } from '/resources/js/stores/instruments'
+import { useHireStore } from '/resources/js/stores/hires'
+
+import HiresList from '../../components/Restricted/Instruments/Hires/HiresList.vue'
+import HireDetails from '../../components/Restricted/Instruments/Hires/HireDetails.vue'
 
 
 const instrumentRoutes = [
@@ -12,8 +16,19 @@ const instrumentRoutes = [
           const instrumentStore = useInstrumentStore()
           if(Object.keys(instrumentStore.getInstrument) == 0) next({ name: 'InstrumentList'})
           else next()
-        }
-      },
+          }
+        },
+        {path: 'hire', meta: {breadcrumb: "Hires", breadcrumb: "Hires"},
+        children: [
+          { path: '', name: 'HiresList', component: HiresList, meta: { title: 'Hires', section: "Instruments", depth: 2}},
+          { path: 'details', name: 'HireDetails', component: HireDetails, meta: { title: 'Hire Details', breadcrumb: ' > Details', section: "Instruments", depth: 3},
+          beforeEnter: (to, from, next) => {
+            const hireStore = useHireStore()
+            if(Object.keys(hireStore.getHire).length == 0) next({ name: 'HiresList'})
+            else next()
+          }
+        },
+    ]},
   ]},
 ] 
 

--- a/resources/js/router/authRoutes/Lessons.js
+++ b/resources/js/router/authRoutes/Lessons.js
@@ -3,7 +3,7 @@ import LessonDetails from '../../components/Restricted/Lessons/LessonDetails.vue
 import LessonCreate from '../../components/Restricted/Lessons/LessonCreate.vue'
 import LessonEdit from '../../components/Restricted/Lessons/Modals/LessonEdit.vue'
 import LessonCreateNote from '../../components/Restricted/Lessons/Modals/Notes/LessonCreateNote.vue'
-import LessonNotes from '../../components/Restricted/Lessons/Modals/Notes/LessonNotes.vue'
+import LessonNotes from '../../components/Restricted/Lessons/LessonNotes.vue'
 import LessonConfirmActive from '../../components/Restricted/Lessons/Modals/LessonConfirmActive.vue'
 import LessonDateTime from '../../components/Restricted/Lessons/Modals/LessonDateTime.vue'
 
@@ -36,7 +36,9 @@ const lessonsRoutes = [
                 { path: 'confirm-active', name: 'LessonConfirmActive', component: LessonConfirmActive, props: true, meta: { title: 'Lesson Details', showModal: true} },
                 { path: 'confirm-date-time', name: 'LessonDateTime', component: LessonDateTime, props: true, meta: { title: 'Lesson Date and Time', showModal: true} },
             ]},
-            { path: 'notes', name: 'LessonNotes', component: LessonNotes, props: true, meta: { title: 'Lesson Notes', section: "Lessons", depth: 3 } },
+            // View Notes
+            { path: 'notes', name: 'LessonNotes', component: LessonNotes, props: true, meta: { title: 'Lesson Notes', breadcrumb: ' > Notes', section: "Lessons", depth: 3 } },
+            // View Single Lesson Attendance
             { path: 'attendance', name: 'LessonAttendanceSingle', component: LessonAttendanceSingle, props: true, meta: { title: 'Lesson Attendance', breadcrumb: ' > Attendance', section: "Lessons", depth: 3} },
           ] },
 

--- a/resources/js/router/authRoutes/authRoutes.js
+++ b/resources/js/router/authRoutes/authRoutes.js
@@ -6,6 +6,7 @@ import dashboardRoutes from './Dashboard';
 import staffRoutes from './Staff';
 import studentsRoutes from './Students';
 import instrumentRoutes from './Instruments';
+// import hireRoutes from './Hires';
 
 const authRoutes = [
   {
@@ -24,6 +25,7 @@ const authRoutes = [
       ...staffRoutes,
       ...studentsRoutes,
       ...instrumentRoutes,
+      // ...hireRoutes,
     ], 
     props: true
   },

--- a/resources/js/stores/hires.js
+++ b/resources/js/stores/hires.js
@@ -1,0 +1,40 @@
+import { defineStore } from "pinia";
+
+function getState(){
+    return {
+      currentHire: {},
+      hires: [],
+      filteredHires: []
+    }
+}
+
+export const useHireStore = defineStore('hires', {
+  state: () => (getState()),
+  actions: {
+    setHire(hireObject){
+      this.currentHire = hireObject
+    },
+    setHires(hireArray){
+      this.hires = hireArray
+    },
+    setFilteredHires(hireArray){
+      this.filteredHires = hireArray
+    },
+    reset(){
+      this.currentHire = {}
+      this.hires = []
+      this.filteredHires = []
+    }
+  },
+  getters: {
+    getHire(){
+      return this.currentHire
+    },
+    getHires(){
+      return this.hires
+    },
+    getFilteredHires(){
+      return this.filteredHires
+    }
+  }
+})

--- a/resources/sass/_colours.scss
+++ b/resources/sass/_colours.scss
@@ -2,8 +2,6 @@
 // $ah-primary: #3b657f;
 
 $ah-primary: #3B6580;
-// $ah-primary: #734588;
-$ah-primary-alt: #3C7DA6;
 $ah-primary-light: lighten($ah-primary, 8%);
 $ah-primary-lighter: lighten($ah-primary, 20%);
 $ah-primary-dark: darken($ah-primary, 8%);
@@ -22,6 +20,7 @@ $ah-background-dark: darken($ah-background, 20%);
 
 $ah-green: #0c6112;
 $ah-green-light: lighten($ah-green, 8%);
+$ah-green-lighter: lighten($ah-green, 20%);
 $ah-green-dark: darken($ah-green, 8%);
 $ah-green-background: lighten($ah-green, 55%);
 

--- a/resources/sass/_elements.scss
+++ b/resources/sass/_elements.scss
@@ -12,3 +12,46 @@
   width: 2rem;
   height: 2rem;
 }
+
+// Large Format Table
+table {
+  table-layout: fixed;
+  width: 100%;
+  thead {
+    background-color: $ah-primary;
+    color: white;
+    tr {
+      th {
+        &:first-child {
+          padding-left: 10px;
+          padding-top: 5px;
+          padding-bottom: 5px;
+        }
+      }
+    }
+  }
+  tbody {
+    tr {
+      border-bottom: 1px solid $ah-grey;
+      &:hover {
+        background-color: $ah-primary-background;
+        cursor: pointer;
+      }
+      td {
+        &:first-child {
+          padding: 10px;
+        }
+      }
+    }
+  }
+}
+#table-body-section {
+  max-height: calc(100vh - 200px);
+  border-bottom: 5px solid $ah-primary;
+}
+.totals {
+  padding-left: 10px;
+  display: inline-flex;
+  align-items: flex-end;
+  justify-content: space-between;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AvatarController;
 use App\Http\Controllers\CalendarEventController;
 use App\Http\Controllers\ContactsController;
+use App\Http\Controllers\HiresController;
 use App\Http\Controllers\ImageController;
 use App\Http\Controllers\InstrumentsController;
 use App\Http\Controllers\LessonAttendanceController;
@@ -46,6 +47,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::post('/image', [ImageController::class, 'storeImage']);
     Route::resource('instruments', InstrumentsController::class);
     Route::get('instrument-states', [InstrumentsController::class, 'getInstrumentStates']);
+    Route::resource('hires', HiresController::class);
 
     Route::resource('/lesson-attendance', LessonAttendanceController::class);
     Route::resource('/lesson-notes', LessonNotesController::class);


### PR DESCRIPTION
Changes made to header layouts and actions tab to ensure only 'actions' are in the side menu and all other routing is on the page. Routing will remain blue (primary) while actions are to be signalled by orange (secondary) going forward